### PR TITLE
update example documentation for allowedRemotePort

### DIFF
--- a/docs/rest.asciidoc
+++ b/docs/rest.asciidoc
@@ -58,7 +58,7 @@ $ curl -H "Content-Type: application/json" -XPUT http://localhost:1700/v1/insert
 	"systemId": "systemId", \
 	"systemType": "systemType", \
 	"password": "password", \
-	"allowedRemoteAddress": [127, 0, 0, 1], \
+	"allowedRemoteAddress": "127.0.0.1", \
 	"allowedRemotePort": aSourcePortNumber \
 }'
 ----


### PR DESCRIPTION
- the type of allowedRemotePort for
  server connections in the
  SMPP Inserter Interface changed from
  byteArray to string